### PR TITLE
fixes a few bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin is the simplest floating window to take input.
 Note this plugin uses a new [parameter](https://github.com/neovim/neovim/pull/20184),
 which requires neovim nightly build or the upcoming 0.9 release.
 
-Add `liangxianzhe/floating-input` to your plugin manager, no setup is required.
+Add `liangxianzhe/floating-input.nvim` to your plugin manager, no setup is required.
 
 Default is to put floating window under the cursor for LSP renaming, and at the center for other use cases. 
 

--- a/lua/floating-input.lua
+++ b/lua/floating-input.lua
@@ -19,6 +19,7 @@ end
 function M.input(opts, on_confirm, win_config)
 	local prompt = opts.prompt or "Input: "
 	local default = opts.default or ""
+	on_confirm = on_confirm or function() end
 
 	-- Calculate a minimal width with a bit buffer
 	local default_width = vim.str_utfindex(default) + 10
@@ -56,18 +57,20 @@ function M.input(opts, on_confirm, win_config)
 	-- Enter to confirm
 	vim.keymap.set({ "n", "i", "v" }, "<cr>", function()
 		local lines = vim.api.nvim_buf_get_lines(buffer, 0, 1, false)
-		if lines[1] ~= default and on_confirm then
-			on_confirm(lines[1])
-		end
-		vim.api.nvim_win_close(window, true)
 		vim.cmd("stopinsert")
+		on_confirm(lines[1])
+		vim.api.nvim_win_close(window, true)
 	end, { buffer = buffer })
 
 	-- Esc or q to close
 	vim.keymap.set("n", "<esc>", function()
+		on_confirm(nil)
+		vim.cmd("stopinsert")
 		vim.api.nvim_win_close(window, true)
 	end, { buffer = buffer })
 	vim.keymap.set("n", "q", function()
+		on_confirm(nil)
+		vim.cmd("stopinsert")
 		vim.api.nvim_win_close(window, true)
 	end, { buffer = buffer })
 end

--- a/plugin/floating-input.lua
+++ b/plugin/floating-input.lua
@@ -1,1 +1,4 @@
-vim.ui.input = function(opts, on_confirm) require("floating-input").input(opts, on_confirm, {}) end
+vim.ui.input = function(opts, on_confirm)
+	opts = opts or {}
+	require("floating-input").input(opts, on_confirm, {})
+end


### PR DESCRIPTION
 - wrong plugin name given in the readme for installation
 - fix errors when called with no `opts` argument (it can be nil as per docs)
 - `on_confirm` is supposed to be called regardless of the default value and it's a required parameter
 - `on_confirm` should be called with `nil` when the input is canceled
 - call `stopinsert` before closing the floating window, so that it doesn't affect the window from which the input was created

I saw that you explicitly added the possibility to skip calling `on_confirm` if the value typed was the same as the default one, but for what I understand from `vim.ui.input` docs the callback should be called regardless. That makes sense since it's required and the caller would have no way to tell what happened if it's never called.

Feel free to merge this or not, it's just a few things that make sense to me in the perspective of using this plugin to replace the default `vim.ui.input` facility :) 