### PR TITLE
Close the input window before executing callbacks

### DIFF
--- a/lua/floating-input.lua
+++ b/lua/floating-input.lua
@@ -58,20 +58,20 @@ function M.input(opts, on_confirm, win_config)
 	vim.keymap.set({ "n", "i", "v" }, "<cr>", function()
 		local lines = vim.api.nvim_buf_get_lines(buffer, 0, 1, false)
 		vim.cmd("stopinsert")
-		on_confirm(lines[1])
 		vim.api.nvim_win_close(window, true)
+		on_confirm(lines[1])
 	end, { buffer = buffer })
 
 	-- Esc or q to close
 	vim.keymap.set("n", "<esc>", function()
-		on_confirm(nil)
 		vim.cmd("stopinsert")
 		vim.api.nvim_win_close(window, true)
+		on_confirm(nil)
 	end, { buffer = buffer })
 	vim.keymap.set("n", "q", function()
-		on_confirm(nil)
 		vim.cmd("stopinsert")
 		vim.api.nvim_win_close(window, true)
+		on_confirm(nil)
 	end, { buffer = buffer })
 end
 


### PR DESCRIPTION
Execute the `on_confirm` callback after the floating input window has closed so that any code in the callback which references the current buffer window (i.e. with the `0` window handle) will act on the underlying window and not the floating input window.